### PR TITLE
fix(android): avoid duplicate share events on cold start

### DIFF
--- a/android/src/main/java/app/capgo/sharetarget/CapacitorShareTargetPlugin.java
+++ b/android/src/main/java/app/capgo/sharetarget/CapacitorShareTargetPlugin.java
@@ -24,12 +24,6 @@ public class CapacitorShareTargetPlugin extends Plugin {
     private static final String pluginVersion = "7.0.0";
 
     @Override
-    public void load() {
-        super.load();
-        handleIntent(getActivity().getIntent());
-    }
-
-    @Override
     protected void handleOnNewIntent(Intent intent) {
         super.handleOnNewIntent(intent);
         handleIntent(intent);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What
- Remove redundant launch-intent handling from the Android plugin's `load()` method.

## Why
- On Android cold start, share intents were delivered twice (~1s apart) because both `load()` and Capacitor's `handleOnNewIntent` replay processed the same launch intent.
- Capacitor's `BridgeActivity.load()` already calls `onNewIntent(getIntent())` after plugins load, so the plugin's own `load()` handling was redundant.

Fixes #38

## How
- Deleted the `load()` override that called `handleIntent(getActivity().getIntent())`.
- Cold-start shares are now handled only via `handleOnNewIntent`, which Capacitor invokes for both the initial launch intent and subsequent warm-start shares.

## Testing
- `bun run lint` — pass
- `bun run verify:web` — pass
- `bun run verify:android` — not run locally (no Android SDK in agent environment); CI will verify

## Not Tested
- Manual cold-start / warm-start share on a physical Android device (relies on CI and code-path analysis of Capacitor `BridgeActivity`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9767a7b9-24b4-41ba-a4c2-4b4ae84ddbc1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9767a7b9-24b4-41ba-a4c2-4b4ae84ddbc1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capacitor-share-target/pr/39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789215341&installation_model_id=430928&pr_number=39&repository=Cap-go%2Fcapacitor-share-target&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapacitor-share-target%2Fpull%2F39&signature=2e49940a5fdd5b7cbe386ab90119f9d12578ce7cb2a5963b2e69786ce67b5c21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-share-target/pull/39?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Android share-target handling when the app receives new share intents.
  * Ensured incoming shared content is processed reliably while the app is already running.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->