### PR TITLE
fix(android): use typed Intent parcelable extras

### DIFF
--- a/android/src/main/java/app/capgo/sharetarget/CapacitorShareTargetPlugin.java
+++ b/android/src/main/java/app/capgo/sharetarget/CapacitorShareTargetPlugin.java
@@ -3,6 +3,7 @@ package app.capgo.sharetarget;
 import android.content.Intent;
 import android.database.Cursor;
 import android.net.Uri;
+import android.os.Build;
 import android.provider.OpenableColumns;
 import android.util.Log;
 import android.webkit.MimeTypeMap;
@@ -59,7 +60,7 @@ public class CapacitorShareTargetPlugin extends Plugin {
                 // Get files
                 JSArray files = new JSArray();
                 if (Intent.ACTION_SEND.equals(action)) {
-                    Uri fileUri = intent.getParcelableExtra(Intent.EXTRA_STREAM);
+                    Uri fileUri = getStreamUri(intent);
                     if (fileUri != null) {
                         JSObject fileData = getFileData(fileUri);
                         if (fileData != null) {
@@ -67,7 +68,7 @@ public class CapacitorShareTargetPlugin extends Plugin {
                         }
                     }
                 } else if (Intent.ACTION_SEND_MULTIPLE.equals(action)) {
-                    ArrayList<Uri> fileUris = intent.getParcelableArrayListExtra(Intent.EXTRA_STREAM);
+                    ArrayList<Uri> fileUris = getStreamUris(intent);
                     if (fileUris != null) {
                         for (Uri fileUri : fileUris) {
                             JSObject fileData = getFileData(fileUri);
@@ -86,6 +87,30 @@ public class CapacitorShareTargetPlugin extends Plugin {
                 Log.e(TAG, "Error handling shared content", e);
             }
         }
+    }
+
+    private static Uri getStreamUri(Intent intent) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            return intent.getParcelableExtra(Intent.EXTRA_STREAM, Uri.class);
+        }
+        return getStreamUriLegacy(intent);
+    }
+
+    @SuppressWarnings("deprecation")
+    private static Uri getStreamUriLegacy(Intent intent) {
+        return intent.getParcelableExtra(Intent.EXTRA_STREAM);
+    }
+
+    private static ArrayList<Uri> getStreamUris(Intent intent) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            return intent.getParcelableArrayListExtra(Intent.EXTRA_STREAM, Uri.class);
+        }
+        return getStreamUrisLegacy(intent);
+    }
+
+    @SuppressWarnings("deprecation")
+    private static ArrayList<Uri> getStreamUrisLegacy(Intent intent) {
+        return intent.getParcelableArrayListExtra(Intent.EXTRA_STREAM);
     }
 
     private JSObject getFileData(Uri uri) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What
- Replace deprecated untyped `Intent.getParcelableExtra` / `getParcelableArrayListExtra` calls when reading `EXTRA_STREAM` in `handleIntent`.
- Add small helpers that use typed overloads on API 33+ (`TIRAMISU`) and legacy deprecated calls with `@SuppressWarnings("deprecation")` on API 24–32.

## Why
- Android release builds with `compileSdk 36` emit deprecation warnings for untyped parcelable extras.
- Fixes #40.

## How
- Follow the same Cap-go pattern used in other plugins (`InternalUtils`, etc.): `SDK_INT >= TIRAMISU` → typed API; otherwise legacy call with local suppression.
- No minSdk bump; share-received behavior unchanged.

## Testing
- `bun run fmt`
- Android `verify:android` not run locally (no Android SDK in cloud agent environment); CI will run full verification.

## Not Tested
- Manual share-to-app flows on device/emulator.
- No new unit tests: existing Android tests are placeholder examples only; adding Robolectric would be out of scope for this fix.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-565c4612-63a5-44a7-b8cc-cd978e92d3b5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-565c4612-63a5-44a7-b8cc-cd978e92d3b5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capacitor-share-target/pr/41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789644722&installation_model_id=430928&pr_number=41&repository=Cap-go%2Fcapacitor-share-target&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapacitor-share-target%2Fpull%2F41&signature=389d3f57faa6a3aaa10271ca13b1a9881671f8e2b39ab5e1a7c40129fa19ac6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-share-target/pull/41?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

