### PR TITLE
fix(android): use typed Intent parcelable extras

### DIFF
--- a/android/src/main/java/app/capgo/sharetarget/CapacitorShareTargetPlugin.java
+++ b/android/src/main/java/app/capgo/sharetarget/CapacitorShareTargetPlugin.java
@@ -3,6 +3,7 @@ package app.capgo.sharetarget;
 import android.content.Intent;
 import android.database.Cursor;
 import android.net.Uri;
+import android.os.Build;
 import android.provider.OpenableColumns;
 import android.util.Log;
 import android.webkit.MimeTypeMap;
@@ -59,7 +60,12 @@ public class CapacitorShareTargetPlugin extends Plugin {
                 // Get files
                 JSArray files = new JSArray();
                 if (Intent.ACTION_SEND.equals(action)) {
-                    Uri fileUri = intent.getParcelableExtra(Intent.EXTRA_STREAM);
+                    Uri fileUri;
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                        fileUri = intent.getParcelableExtra(Intent.EXTRA_STREAM, Uri.class);
+                    } else {
+                        fileUri = getParcelableExtraLegacy(intent, Intent.EXTRA_STREAM);
+                    }
                     if (fileUri != null) {
                         JSObject fileData = getFileData(fileUri);
                         if (fileData != null) {
@@ -67,7 +73,12 @@ public class CapacitorShareTargetPlugin extends Plugin {
                         }
                     }
                 } else if (Intent.ACTION_SEND_MULTIPLE.equals(action)) {
-                    ArrayList<Uri> fileUris = intent.getParcelableArrayListExtra(Intent.EXTRA_STREAM);
+                    ArrayList<Uri> fileUris;
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                        fileUris = intent.getParcelableArrayListExtra(Intent.EXTRA_STREAM, Uri.class);
+                    } else {
+                        fileUris = getParcelableArrayListExtraLegacy(intent, Intent.EXTRA_STREAM);
+                    }
                     if (fileUris != null) {
                         for (Uri fileUri : fileUris) {
                             JSObject fileData = getFileData(fileUri);
@@ -86,6 +97,16 @@ public class CapacitorShareTargetPlugin extends Plugin {
                 Log.e(TAG, "Error handling shared content", e);
             }
         }
+    }
+
+    @SuppressWarnings("deprecation")
+    private Uri getParcelableExtraLegacy(Intent intent, String key) {
+        return intent.getParcelableExtra(key);
+    }
+
+    @SuppressWarnings("deprecation")
+    private ArrayList<Uri> getParcelableArrayListExtraLegacy(Intent intent, String key) {
+        return intent.getParcelableArrayListExtra(key);
     }
 
     private JSObject getFileData(Uri uri) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What
- Use API 33+ typed `Intent.getParcelableExtra` / `getParcelableArrayListExtra` for `EXTRA_STREAM` in `ACTION_SEND` and `ACTION_SEND_MULTIPLE`.
- Add legacy helpers with `@SuppressWarnings("deprecation")` for API 24–32.

Fixes #40

## Why
- Android release builds with `compileSdk 36` warn about deprecated untyped parcelable extra APIs.
- Typed overloads are required on API 33+; legacy calls remain needed for older devices.

## How
- Follow the same pattern used in `@capacitor/share` (`SharePlugin`): branch on `Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU`, use typed extras on API 33+, and isolate deprecated calls in small private helpers.
- No minSdk bump; share handling logic is unchanged.

## Testing
- `bun run verify:android` (clean build + unit tests) — success
- Release compile checked with `-Xlint:deprecation` — no deprecation warnings from `CapacitorShareTargetPlugin.java`

## Not Tested
- On-device share receive flows (ACTION_SEND / ACTION_SEND_MULTIPLE) — behavior is unchanged; only Intent extra extraction API selection differs by SDK level.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ee574fb8-639d-473e-bd46-ec1b28db8dac?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ee574fb8-639d-473e-bd46-ec1b28db8dac&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capacitor-share-target/pr/42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789644755&installation_model_id=430928&pr_number=42&repository=Cap-go%2Fcapacitor-share-target&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapacitor-share-target%2Fpull%2F42&signature=d3d73b5ba27dc821e0b0749a0213f82675e26312def20c69e58e6538cb32f5e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-share-target/pull/42?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

